### PR TITLE
Simplify release binary name to just 'trigger-captive-portal'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: "1.20"
           cache: true
-      - name: Build a release binary and checksums.txt. Upload
+      - name: Build and publish the release binary and checksums.txt
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
+project_name: trigger-captive-portal
 
 builds:
   - env:
@@ -10,16 +11,17 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X main.version={{ .Version }}
 
 universal_binaries:
   - replace: true
 
 archives:
   - format: binary
+    name_template: "{{ .ProjectName }}"
 
 checksum:
-  name_template: "checksums.txt"
+  name_template: checksums.txt
 
 snapshot:
   name_template: "{{ incpatch .Version }}-next"


### PR DESCRIPTION
By default, the binary has a bunch of version and platform info in its name. The platform info doesn't matter because we're building a universal binary for macOS. Removing the version makes it so the user doesn't have to rename the file after it's downloaded.
