### PR TITLE
Publish the release binary as a tarball to preserve executable permissions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,12 +17,9 @@ universal_binaries:
   - replace: true
 
 archives:
-  - format: binary
+  # Publish the binary in a tarball to preserve it's executable permissions.
+  - format: tar.gz
     name_template: "{{ .ProjectName }}"
-    builds_info:
-      group: root
-      owner: root
-      mode: 0755 # make the binary executable
 
 checksum:
   name_template: checksums.txt

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ work.
 
 ## Install
 
-This will download the binary to `/usr/local/bin`, which is in your `$PATH`.
+This will download the macOS binary to `/usr/local/bin`, which is in your
+`$PATH`. It's a universal binary, so it will work on both Intel and Apple
+Silicon Macs.
 
 ```zsh
-curl --retry 3 --retry-max-time 120 -sSL https://github.com/ryboe/trigger-captive-portal/releases/latest/download/trigger-captive-portal | sudo tee /usr/local/bin/trigger-captive-portal > /dev/null
+curl --retry 3 --retry-max-time 120 -sSL https://github.com/ryboe/trigger-captive-portal/releases/latest/download/trigger-captive-portal | sudo tar -xzf - -C /usr/local/bin
 ```
 
 ## Usage


### PR DESCRIPTION
Update the installation instructions to extract the tarball to `/usr/local/bin`. This makes it possible to download and install the binary in one command.
