### PR TITLE
Remove the LICENSE and the README from the release tarball

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,8 @@ archives:
   # Publish the binary in a tarball to preserve it's executable permissions.
   - format: tar.gz
     name_template: "{{ .ProjectName }}"
+    files:
+      - trigger-captive-portal
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
We don't want to extract the tarball to `/usr/local/bin` and pollute the directory with the LICENSE and README files.