### PR TITLE
Extract only the binary during installation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,8 +20,6 @@ archives:
   # Publish the binary in a tarball to preserve it's executable permissions.
   - format: tar.gz
     name_template: "{{ .ProjectName }}"
-    files:
-      - trigger-captive-portal
 
 checksum:
   name_template: checksums.txt

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This will download the macOS binary to `/usr/local/bin`, which is in your
 Silicon Macs.
 
 ```zsh
-curl --retry 3 --retry-max-time 120 -sSL https://github.com/ryboe/trigger-captive-portal/releases/latest/download/trigger-captive-portal | sudo tar -xzf - -C /usr/local/bin
+curl --retry 3 --retry-max-time 120 -sSL https://github.com/ryboe/trigger-captive-portal/releases/latest/download/trigger-captive-portal | sudo tar -xzf - -C /usr/local/bin trigger-captive-portal
 ```
 
 ## Usage


### PR DESCRIPTION
My previous attempt to remove the `LICENSE` and the `README.md` from the release tarball failed. My new approach is to extract only the binary from the archive and copy it to `/usr/local/bin`.
