### PR TITLE
fix: Fallback to Chromium not working. Also add Brave browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ curl --retry 3 --retry-max-time 120 -sSL https://github.com/ryboe/trigger-captiv
 
 ## Usage
 
-Just type this command in your terminal. You may need to close Chrome before
-running it.
+Just type this command in your terminal. You may need to close your browser
+before running it. If it fails, try running it multiple times.
 
 ```zsh
 trigger-captive-portal


### PR DESCRIPTION
The browser name was being dynamically fetched, but I wasn't using it in the final command that makes the unsecured HTTP request. "Google Chrome" was hardcoded instead. Now I'm actually using the fetched name. I also added "Brave Browser" as another fallback option, based on a user request.

Resolve #12 